### PR TITLE
Correctly display newlines returned by the server

### DIFF
--- a/lua/curl/api.lua
+++ b/lua/curl/api.lua
@@ -141,10 +141,10 @@ M.execute_curl = function()
 			buffers.set_output_buffer_content(executed_from_win, parsed_output)
 		end,
 		on_stdout = function(_, data, _)
-			output = output .. vim.fn.join(data)
+			output = output .. table.concat(data, "\n")
 		end,
 		on_stderr = function(_, data, _)
-			error = error .. vim.fn.join(data)
+			error = error .. table.concat(data, "\n")
 		end,
 	})
 end

--- a/lua/curl/output_parser.lua
+++ b/lua/curl/output_parser.lua
@@ -63,7 +63,10 @@ M.parse_curl_output = function(curl_standard_out)
 		return run_jq(curl_standard_out)
 	end
 
-	local output_table = vim.split(curl_standard_out, "\r")
+	-- Replace all \r\n and stray \r with standard \n
+	local clean_out = curl_standard_out:gsub("\r\n", "\n"):gsub("\r", "\n")
+	-- Split cleanly. No invisible \r characters will corrupt the Neovim buffer!
+	local output_table = vim.split(clean_out, "\n")
 	local header_lines, json_string = extract_json(output_table)
 
 	if json_string == nil then


### PR DESCRIPTION
For example a curl request might respond with:
Error: asdf
Stacktrace:
File1....
File2...

That previously was concaticated to one single row and very hard to read